### PR TITLE
fix: remove NTP setup as a workaround for Ubuntu 20.04 over WSL2

### DIFF
--- a/.tags
+++ b/.tags
@@ -1,0 +1,14 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.9~svn20110310	//
+cd	playbooks/roles/zsh/files/cdenv.plugin.zsh	/^function cd() {$/;"	f
+findm	playbooks/roles/zsh/files/findm.plugin.zsh	/^function findm(){$/;"	f
+grepr	playbooks/roles/zsh/files/grepr.plugin.zsh	/^function grepr(){$/;"	f
+mclone	playbooks/roles/zsh/files/mclone.plugin.zsh	/^function mclone(){$/;"	f
+print_green	init_ssh_key.sh	/^function print_green(){$/;"	f
+print_green	quickstart.sh	/^function print_green(){$/;"	f
+print_green	update_ssh_config.sh	/^function print_green(){$/;"	f
+usage	playbooks/roles/zsh/files/mclone.plugin.zsh	/^    usage() { echo "usage: mclone [-g] REPOSITORY [DIRECTORY]";}$/;"	f

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -14,6 +14,3 @@
   become: yes
   when: ansible_distribution == "Ubuntu"
 
-- name: setup NTP
-  import_tasks: ntp.yml
-  when: ansible_distribution == "Ubuntu"


### PR DESCRIPTION
Workaround that fixes #15, but removes NTP setup. 
