### PR TITLE
Chore/update certbot packages

### DIFF
--- a/playbooks/roles/certbot/tasks/main.yml
+++ b/playbooks/roles/certbot/tasks/main.yml
@@ -12,18 +12,6 @@
   package_facts:
     manager: auto
 
-- name: add certbot ppa
-  apt_repository:
-    repo: 'ppa:certbot/certbot'
-    codename: bionic
-    state: present
-  become: yes
-  when:
-    - "'nginx' in ansible_facts.packages"
-    -  ansible_distribution == "Ubuntu"
-  tags:
-    - certbot
-
 - name: install certbot and nginx plugin
   apt:
     name:

--- a/playbooks/roles/certbot/tasks/main.yml
+++ b/playbooks/roles/certbot/tasks/main.yml
@@ -28,7 +28,7 @@
   apt:
     name:
       - certbot
-      - python-certbot-nginx
+      - python3-certbot-nginx
   become: yes
   when:
     - "'nginx' in ansible_facts.packages"


### PR DESCRIPTION
https://launchpad.net/~certbot/+archive/ubuntu/certbot dice _The PPA has been DEPRECATED._

acabo de probar estos cambios en ubuntu 20 y funcionan

no los probé en ubuntu 18, pero deberian funcionar (https://packages.ubuntu.com/bionic-updates/certbot, https://packages.ubuntu.com/bionic/python3-certbot-nginx)