### PR TITLE
feat: add oh-my-zsh plugins for docker, compose and systemd

### DIFF
--- a/playbooks/roles/zsh/files/docker-extra.plugin.zsh
+++ b/playbooks/roles/zsh/files/docker-extra.plugin.zsh
@@ -1,0 +1,5 @@
+# See docker plugin Readme (~/.oh-my-zsh/plugins/docker/README.md)
+zstyle ':completion:*:*:docker:*' option-stacking yes
+zstyle ':completion:*:*:docker-*:*' option-stacking yes
+
+alias dcupbd="docker-compose up --build -d"

--- a/playbooks/roles/zsh/tasks/main.yml
+++ b/playbooks/roles/zsh/tasks/main.yml
@@ -6,12 +6,15 @@
     oh_my_zsh_plugins:
       - autojump
       - command-not-found
+      - docker
+      - docker-compose
       - encode64
       - git
       - git-flow
       - github
       - history-substring-search
       - pip
+      - systemd
     oh_my_zsh_theme: dieter
   tags: zsh
 


### PR DESCRIPTION
para los aliases `dcps` en vez de `docker-compose ps`

y `sc-reload nginx` en vez de `sudo systemctl reload nginx`