### PR TITLE
fix: set own gid to admin user

### DIFF
--- a/playbooks/vps_init.yml
+++ b/playbooks/vps_init.yml
@@ -37,6 +37,7 @@
     - name: add admin user with sudo as additional group
       user:
         name: "{{ admin_user }}"
+        group: "{{ admin_user }}"   # Without this, gid=100(users)
         groups: "{{ admin_user }},sudo"
         append: yes
         password: "{{ admin_user_password }}"


### PR DESCRIPTION
antes:
```
$ ls -lA /home/magnet
total 12
-rw-r--r-- 1 magnet users  220 Feb 25  2020 .bash_logout
-rw-r--r-- 1 magnet users 3771 Feb 25  2020 .bashrc
-rw-r--r-- 1 magnet users  807 Feb 25  2020 .profile

$ ls -lA --numeric-uid-gid /home/magnet
total 12
-rw-r--r-- 1 1002 100  220 Feb 25  2020 .bash_logout
-rw-r--r-- 1 1002 100 3771 Feb 25  2020 .bashrc
-rw-r--r-- 1 1002 100  807 Feb 25  2020 .profile
```

despues:
```
$ ls -lA /home/magnet
total 12
-rw-r--r-- 1 magnet magnet  220 Feb 25  2020 .bash_logout
-rw-r--r-- 1 magnet magnet 3771 Feb 25  2020 .bashrc
-rw-r--r-- 1 magnet magnet  807 Feb 25  2020 .profile

$ ls -lA --numeric-uid-gid /home/magnet
total 12
-rw-r--r-- 1 1002 1002  220 Feb 25  2020 .bash_logout
-rw-r--r-- 1 1002 1002 3771 Feb 25  2020 .bashrc
-rw-r--r-- 1 1002 1002  807 Feb 25  2020 .profile
```

el grupo `users` es como para que todos los usuarios se compartan todo por defecto. segun https://wiki.archlinux.org/title/users_and_groups, _The primary group for users when user private groups are not used (generally not recommended)_

respecto a seguridad, como solemos tener solo 1 usuario en los servidores, esto da lo mismo. pero me esta haciendo conflicto con un container en D3PT