### PR TITLE
fix: read magnet ssh_config directly

### DIFF
--- a/inventory/ssh_config.py
+++ b/inventory/ssh_config.py
@@ -52,7 +52,7 @@ import paramiko
 
 from ansible.module_utils.common._collections_compat import MutableSequence
 
-SSH_CONF = '~/.ssh/config'
+SSH_CONF = '~/.ssh/config.d/magnet'
 
 _key = 'ssh_config'
 

--- a/inventory_root/ssh_config.py
+++ b/inventory_root/ssh_config.py
@@ -52,7 +52,7 @@ import paramiko
 
 from ansible.module_utils.common._collections_compat import MutableSequence
 
-SSH_CONF = '~/.ssh/config'
+SSH_CONF = '~/.ssh/config.d/magnet'
 
 _key = 'ssh_config'
 


### PR DESCRIPTION
Paramiko aún no soporta el parseo de directivas Import por lo que nuestra config traída desde keygen no se carga.
Mientras el PR de paramiko (#1892) no se apruebe, cargar la configuración directamente.