### PR TITLE
fix: pass users variable to ssh role when initializing VMs

### DIFF
--- a/playbooks/vps_init.yml
+++ b/playbooks/vps_init.yml
@@ -82,6 +82,9 @@
     - role: ssh
       tags:
         - init
+      vars:
+        users:
+          - username: "{{ admin_user }}"
     - role: common
       tags:
         - init


### PR DESCRIPTION
Algo pasó, no sé si en mi local o los requirements, pero el role de ssh ahora falla porque no recibe la variable `users`.
(Hace unos meses cuando aprovisioné una máquina en GCP sí andaba bien)