### PR TITLE
fix: add community.general to requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -8,6 +8,9 @@ collections:
   - name: community.crypto
     version: ">=2.10.0"
 
+  - name: community.general
+    version: ">=7.2.0"
+
   - name: community.digitalocean
     version: ">=1.22.0"
 


### PR DESCRIPTION
Tengo `ansible-core` y se me cayó un playbook porque no estaba esta colección.
Lo bueno es que así tenemos mayor control de las dependencias.