### PR TITLE
chore: remove node installation from vps_init and developer playbooks [MD-345]

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ It includes the following roles considering localhost as target:
 
 * common/main
 * zsh
-* node
 * vim
 
 Since the target is localhost, the playbook can be run without specifying an
@@ -149,7 +148,6 @@ It includes the following tasks:
 * Setup NTP.
 * Set swap partition
 * Install zsh, oh-my-zsh and custom plugins.
-* Install node.js (LTS).
 * Install vim and [vim_config](https://github.com/magnet-cl/Vim_config).
 
 To run it against a server with passworded `sudo`, add `--ask-become-pass` (otherwise it fails with _Missing sudo password_).

--- a/playbooks/developer.yml
+++ b/playbooks/developer.yml
@@ -9,10 +9,6 @@
       tags:
         - utils
         - zsh
-    - role: node
-      tags:
-        - utils
-        - node
     - role: vim
       vars:
         users:

--- a/playbooks/roles/node/defaults/main.yml
+++ b/playbooks/roles/node/defaults/main.yml
@@ -1,2 +1,0 @@
----
-path_for_node: "{{ interactive_path | default(omit) }}:{{ ansible_env.PATH }}"

--- a/playbooks/roles/node/tasks/main.yml
+++ b/playbooks/roles/node/tasks/main.yml
@@ -1,9 +1,0 @@
----
-- name: install Node.js
-  include_role:
-    name: geerlingguy.nodejs
-    apply:
-      become: true
-  vars:
-    nodejs_version: 16.x
-    nodejs_install_npm_user: "{{ ansible_user_id }}"

--- a/playbooks/vps_init.yml
+++ b/playbooks/vps_init.yml
@@ -95,11 +95,6 @@
         - init
         - utils
         - zsh
-    - role: node
-      tags:
-        - init
-        - utils
-        - node
     - role: vim
       vars:
         users:

--- a/requirements.yml
+++ b/requirements.yml
@@ -19,10 +19,6 @@ roles:
     src: https://github.com/geerlingguy/ansible-role-docker
     version: 67e50e9af050e89c7d2d323f02a02b2d6812c9c5 # 6.1.0
 
-  - name: geerlingguy.nodejs
-    src: https://github.com/geerlingguy/ansible-role-nodejs
-    version: f9f23697e4c47f170b3ddca6956e85984a4bc0b0 # 6.1.0
-
   - name: gantsign.oh-my-zsh
     src: https://github.com/gantsign/ansible-role-oh-my-zsh
     version: 3f63fc534779f5914f13bebb13c8a0dd23dbbc86 # 2.4.0


### PR DESCRIPTION
Node is no longer required by default