### PR TITLE
feature: add playbook to setup the scout in a server

### DIFF
--- a/playbooks/install_scout.yml
+++ b/playbooks/install_scout.yml
@@ -1,0 +1,34 @@
+---
+- name: install Mothership's scout
+  hosts: all
+
+  vars_prompt:
+    - name: server_name
+      prompt: Server name
+      private: false
+    - name: server_environment
+      prompt: |-
+        Server environment
+          - DEVELOPMENT
+          - QA
+          - PRODUCTION
+          - OTHER
+        choose from the list above
+      private: false
+      default: DEVELOPMENT
+    - name: project_code
+      prompt: Project code
+      private: false
+    - name: known_domain_name
+      prompt: Known domain name
+      private: false
+
+  roles:
+    - role: mothership_scout
+      vars:
+        server_payload:
+          name: '{{ server_name }}'
+          environment: '{{ server_environment }}'
+          project_code: '{{ project_code }}'
+          known_domain_names: ['{{ known_domain_name }}']
+          last_known_ip_address: '{{ ansible_facts["default_ipv4"]["address"] }}'


### PR DESCRIPTION
## What?
Add a standalone playbook that installs the Mothership scout in a server.

## Why?
To enroll servers if they were not initialized by vps_init