### PR TITLE
feat: create standard and admin users when setting up new servers

### DIFF
--- a/playbooks/install_docker.yml
+++ b/playbooks/install_docker.yml
@@ -7,8 +7,8 @@
       vars:
         docker_install_compose: false         # Don't install standalone binary, which is now not recommended
         docker_install_compose_plugin: true   # Use the plugin instead
-        docker_users:
-          - "{{ ansible_user_id }}"
+        docker_users: "{{ [ansible_user_id, 'magnet', 'magnet-admin'] | unique }}"
+
   tasks:
     - name: show hint
       debug:

--- a/playbooks/roles/ssh/tasks/main.yml
+++ b/playbooks/roles/ssh/tasks/main.yml
@@ -22,6 +22,7 @@
   openssh_keypair:
     path: "~{{ item.username }}/.ssh/id_rsa"
     owner: "{{ item.username }}"
+    group: "{{ item.username }}"
   with_items:
     - "{{ users }}"
   become: yes

--- a/playbooks/roles/ssh/tasks/main.yml
+++ b/playbooks/roles/ssh/tasks/main.yml
@@ -5,6 +5,14 @@
     - init
     - security
 
+- name: install acl package to allow ownership change
+  apt:
+    name: acl
+    state: present
+  become: yes
+  when:
+    - ansible_distribution in ["Ubuntu", "Debian"]
+
 - name: create ssh directory
   file:
     path: "~{{ item.username }}/.ssh"
@@ -28,15 +36,6 @@
   become: yes
   tags:
     - init
-
-- name: install acl package to allow ownership change
-  apt:
-    name: acl
-    state: present
-  become: yes
-  when:
-    - ansible_user_id != "root"
-    - ansible_distribution == "Ubuntu"
 
 - name: add github keys to known hosts
   known_hosts:

--- a/playbooks/roles/users/tasks/main.yml
+++ b/playbooks/roles/users/tasks/main.yml
@@ -1,0 +1,65 @@
+---
+- name: add group for standard users
+  group:
+    name: "{{ std_user }}"
+    state: present
+  become: true
+  tags:
+    - init
+
+- name: add group for admin user
+  group:
+    name: "{{ admin_user }}"
+    state: present
+  become: true
+  tags:
+    - init
+
+- name: add standard user
+  user:
+    name: "{{ std_user }}"
+    group: "{{ std_user }}"   # Without this, gid=100(users)
+    groups:
+      - "{{ std_user }}"
+    append: true
+    password: "{{ std_user_password }}"
+    update_password: on_create
+  become: true
+  tags:
+    - init
+
+- name: add administrator user
+  user:
+    name: "{{ admin_user }}"
+    group: "{{ admin_user }}"   # Without this, gid=100(users)
+    # add admin user to the same group as standard user, so that it can read files owned by the standard user
+    groups:
+      - "{{ admin_user }}"
+      - "{{ std_user }}"
+      - sudo
+      - adm   # allows reading /var/log/nginx/* without sudo
+    append: true
+    password: "{{ admin_user_password }}"
+    update_password: on_create
+  become: true
+  tags:
+    - init
+
+- name: add ssh keys of initial admins
+  authorized_key:
+    user: "{{ admin_user }}"
+    state: present
+    key: "https://github.com/{{ item }}.keys"
+  loop: "{{ github_users_as_initial_admins }}"
+  become: true
+  tags:
+    - init
+
+- name: add admin user to sudoers
+  template:
+    src: templates/admin_user_sudoers.j2
+    dest: "/etc/sudoers.d/{{ admin_user }}"
+    mode: 0440
+  become: true
+  tags:
+    - init

--- a/playbooks/roles/users/tasks/main.yml
+++ b/playbooks/roles/users/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: add group for standard users
   group:
-    name: "{{ std_user }}"
+    name: "{{ std_username }}"
     state: present
   become: true
   tags:
@@ -9,7 +9,7 @@
 
 - name: add group for admin user
   group:
-    name: "{{ admin_user }}"
+    name: "{{ admin_username }}"
     state: present
   become: true
   tags:
@@ -17,12 +17,12 @@
 
 - name: add standard user
   user:
-    name: "{{ std_user }}"
-    group: "{{ std_user }}"   # Without this, gid=100(users)
+    name: "{{ std_username }}"
+    group: "{{ std_username }}"   # Without this, gid=100(users)
     groups:
-      - "{{ std_user }}"
+      - "{{ std_username }}"
     append: true
-    password: "{{ std_user_password }}"
+    password: "{{ std_password }}"
     update_password: on_create
   become: true
   tags:
@@ -30,16 +30,16 @@
 
 - name: add administrator user
   user:
-    name: "{{ admin_user }}"
-    group: "{{ admin_user }}"   # Without this, gid=100(users)
+    name: "{{ admin_username }}"
+    group: "{{ admin_username }}"   # Without this, gid=100(users)
     # add admin user to the same group as standard user, so that it can read files owned by the standard user
     groups:
-      - "{{ admin_user }}"
-      - "{{ std_user }}"
+      - "{{ admin_username }}"
+      - "{{ std_username }}"
       - sudo
       - adm   # allows reading /var/log/nginx/* without sudo
     append: true
-    password: "{{ admin_user_password }}"
+    password: "{{ admin_password }}"
     update_password: on_create
   become: true
   tags:
@@ -47,10 +47,20 @@
 
 - name: add ssh keys of initial admins
   authorized_key:
-    user: "{{ admin_user }}"
+    user: "{{ admin_username }}"
     state: present
     key: "https://github.com/{{ item }}.keys"
-  loop: "{{ github_users_as_initial_admins }}"
+  loop: "{{ initial_admin_gh_names }}"
+  become: true
+  tags:
+    - init
+
+- name: add ssh keys of initial admins for standard user
+  authorized_key:
+    user: "{{ std_username }}"
+    state: present
+    key: "https://github.com/{{ item }}.keys"
+  loop: "{{ initial_admin_gh_names }}"
   become: true
   tags:
     - init
@@ -58,7 +68,7 @@
 - name: add admin user to sudoers
   template:
     src: templates/admin_user_sudoers.j2
-    dest: "/etc/sudoers.d/{{ admin_user }}"
+    dest: "/etc/sudoers.d/{{ admin_username }}"
     mode: 0440
   become: true
   tags:

--- a/playbooks/templates/admin_user_sudoers.j2
+++ b/playbooks/templates/admin_user_sudoers.j2
@@ -1,1 +1,1 @@
-{{ admin_user }} ALL=(ALL) NOPASSWD:ALL
+{{ admin_username }} ALL=(ALL) NOPASSWD:ALL

--- a/playbooks/vps_init.yml
+++ b/playbooks/vps_init.yml
@@ -8,15 +8,26 @@
       - nstuardod
 
   vars_prompt:
-    - name: admin_user
-      prompt: "Enter user name to create an admin with sudo"
+    - name: std_user
+      prompt: "Enter user name to create a standard user without sudo"
       default: magnet
       private: false
-    - name: admin_user_password
+    - name: std_user_password
       prompt: "Enter user password"
       private: true
       encrypt: "sha512_crypt"
       confirm: true
+
+    - name: admin_user
+      prompt: "Enter user name to create an administrator with sudo"
+      default: magnet-admin
+      private: false
+    - name: admin_user_password
+      prompt: "Enter administrator password"
+      private: true
+      encrypt: "sha512_crypt"
+      confirm: true
+
     - name: server_name
       prompt: Server name
       private: false
@@ -38,53 +49,15 @@
       private: false
 
   pre_tasks:
+    - name: obtain token for Mothership from env var
+      set_fact:
+        has_mothership_token: '{{ lookup("env", "MOTHERSHIP_USER_KEY") != "" }}'
+
     - name: check that ansible_limit is defined
       assert:
         that: ansible_limit is defined
         fail_msg: Please explicitly limit the hosts you want to target with --limit or -l
         quiet: yes
-
-    - name: add group for admin user
-      group:
-        name: "{{ admin_user }}"
-        state: present
-      become: yes
-      tags:
-        - init
-
-    - name: add admin user with sudo as additional group
-      user:
-        name: "{{ admin_user }}"
-        group: "{{ admin_user }}"   # Without this, gid=100(users)
-        groups:
-          - "{{ admin_user }}"
-          - sudo
-          - adm   # allows reading /var/log/nginx/* without sudo
-        append: yes
-        password: "{{ admin_user_password }}"
-        update_password: on_create
-      become: yes
-      tags:
-        - init
-
-    - name: add ssh keys of initial admins
-      authorized_key:
-        user: "{{ admin_user }}"
-        state: present
-        key: "https://github.com/{{ item }}.keys"
-      loop: "{{ github_users_as_initial_admins }}"
-      become: yes
-      tags:
-        - init
-
-    - name: add admin user to sudoers
-      template:
-        src: templates/admin_user_sudoers.j2
-        dest: "/etc/sudoers.d/{{ admin_user }}"
-        mode: 0440
-      become: yes
-      tags:
-        - init
 
     - name: set default locale
       lineinfile:
@@ -96,11 +69,21 @@
         - init
 
   roles:
+    - role: users
+      tags:
+        - init
+      vars:
+        std_user: "{{ std_user }}"
+        std_user_password: "{{ std_user_password }}"
+        admin_user: "{{ admin_user }}"
+        admin_user_password: "{{ admin_user_password }}"
+        github_users_as_initial_admins: "{{ github_users_as_initial_admins }}"
     - role: ssh
       tags:
         - init
       vars:
         users:
+          - username: "{{ std_user }}"
           - username: "{{ admin_user }}"
     - role: common
       tags:
@@ -108,6 +91,7 @@
     - role: zsh
       vars:
         users:
+          - username: "{{ std_user }}"
           - username: "{{ admin_user }}"
       tags:
         - init
@@ -116,6 +100,7 @@
     - role: vim
       vars:
         users:
+          - username: "{{ std_user }}"
           - username: "{{ admin_user }}"
       tags:
         - init
@@ -152,3 +137,4 @@
       tags:
         - init
         - mothership
+      when: has_mothership_token

--- a/playbooks/vps_init.yml
+++ b/playbooks/vps_init.yml
@@ -73,11 +73,11 @@
       tags:
         - init
       vars:
-        std_user: "{{ std_user }}"
-        std_user_password: "{{ std_user_password }}"
-        admin_user: "{{ admin_user }}"
-        admin_user_password: "{{ admin_user_password }}"
-        github_users_as_initial_admins: "{{ github_users_as_initial_admins }}"
+        std_username: "{{ std_user }}"
+        std_password: "{{ std_user_password }}"
+        admin_username: "{{ admin_user }}"
+        admin_password: "{{ admin_user_password }}"
+        initial_admin_gh_names: "{{ github_users_as_initial_admins }}"
     - role: ssh
       tags:
         - init


### PR DESCRIPTION
## What?

Se crean dos usuarios al configurar un servidor: uno con privilegios y otro sin ellos.

## Why?
Para reducir el riesgo de escalamiento indebido de privilegios y facilitar la identificación de responsables en caso de ocurrido el incidente.

## How?

`vps_init` crea dos usuarios en lugar de solo uno:

* Uno para usuarios normales: desarrolladores, analistas, etc. **No puede usar sudo**.
* Uno para administradores: DevOps, PMs. **Puede usar sudo**.
