### PR TITLE
fix: vars syntax in ssh hardening role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Vim
 .tags
 
 # IDEs
@@ -7,4 +8,3 @@
 # Local inventories
 inventory.yaml
 inventory*.yaml
-


### PR DESCRIPTION
Corregí un error cuando estaba corriendo ansible-playbook -i "<ip>," -l "<ip>" playbooks/vps_init.yml -u root     

  ERROR! Vars in a IncludeRole must be specified as a dictionary.                                                                                                                       
                                                                                                                                                                                        
  The error appears to be in '/home/ignacio/Magnet/magnetizer/playbooks/roles/ssh/tasks/security.yml': line 8, column 5, but may                                                        
  be elsewhere in the file depending on the exact syntax problem.                                                                                                                       
                                                                                                                                                                                        
  The offending line appears to be:                                                                                                                                                     
                                                                                                                                                                                        
    vars:                                                                                                                                                                               
      - sftp_enabled: true                                                                                                                                                              
      ^ here    

vars estaba en formato y lo cambié a diccionario.