### PR TITLE
fix: allow passing MOTHERSHIP_USER_KEY and ssh vars as Ansible variables

### DIFF
--- a/playbooks/roles/mothership_scout/tasks/main.yaml
+++ b/playbooks/roles/mothership_scout/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: obtain token for Mothership from env var
   set_fact:
-    bearer_token: '{{ lookup("env", "MOTHERSHIP_USER_KEY") }}'
+    bearer_token: '{{ MOTHERSHIP_USER_KEY | default(lookup("env", "MOTHERSHIP_USER_KEY")) }}'
 
 - name: fail if Mothership user key is unset
   fail:


### PR DESCRIPTION
Estaba configurando una nueva VPS y aunque incluí en las variables de entorno en .env/bin/activate la variable MOTHERSHIP_USER_KEY, no la detectó. Así que tuve que correr de nuevo el playbook específico pero ahora como una variable. 
Este PR es para agregar esa opción.